### PR TITLE
Rename recipe to match OpenHAB version

### DIFF
--- a/README
+++ b/README
@@ -22,6 +22,21 @@ This layer depends on:
   URI: git://git.yoctoproject.org/meta-oracle-java
   branch: master
 
+  ** Alternative Java repo
+  URI: https://github.com/jrbenito/meta-oracle-java.git
+  branch: master
+
+  The Yocto Project meta-oracle-java layer seems to  be not
+  working  anymore because  Oracle updated its  website and
+  also,  the version this  layer provides is not available.
+  To circumvent this I cloned the  repo above, upgraded the
+  recipe  pointing latest version available  at Oracle site
+  However,  since Oracle  now demands  one to  login before
+  download,  the recipe will  fail  do_fetch. Please follow
+  my repo README instructions in order to manually download
+  package; after that recipe will skip do_fetch and install
+  Java correctly.
+
 
 Patches
 =======

--- a/recipes-core/openhab/openhab_1.6.2.bb
+++ b/recipes-core/openhab/openhab_1.6.2.bb
@@ -7,10 +7,8 @@ PR = "r0"
 
 RDEPENDS_${PN} += "java2-runtime"
 
-OH_VERSION = "1.6.2"
-
-SRC_URI = "https://github.com/openhab/openhab/releases/download/v${OH_VERSION}/distribution-${OH_VERSION}-runtime.zip;name=runtime \
-           https://github.com/openhab/openhab/releases/download/v${OH_VERSION}/distribution-${OH_VERSION}-addons.zip;name=addons \
+SRC_URI = "https://github.com/openhab/openhab/releases/download/v${PV}/distribution-${PV}-runtime.zip;name=runtime \
+           https://github.com/openhab/openhab/releases/download/v${PV}/distribution-${PV}-addons.zip;name=addons \
            file://init"
 
 # runtime package


### PR DESCRIPTION
Doing this we correct set PV variable that can be use inside recipe
as Package Version. This also would diferentiate two recipes for two
different versions of OpenHAB that eventualy can be provided.

Internally, recipe will not need OH_VERSION variable anymore and can
rely on PV for the same job.

If the recipe is updated for some reason (ie overhide do_install) the
PR variable should be incremented to signal bitbake that recipe was
updated. This mechanism seems more aligned with Yocto practices.

Signed-off-by: Josenivaldo Benito Jr jrbenito@benito.qsl.br
