### PR TITLE
Pointing out and meta-oracle-java alternative URL since original is not working anymore.

### DIFF
--- a/README
+++ b/README
@@ -22,6 +22,21 @@ This layer depends on:
   URI: git://git.yoctoproject.org/meta-oracle-java
   branch: master
 
+  ** Alternative Java repo
+  URI: https://github.com/jrbenito/meta-oracle-java.git
+  branch: master
+
+  The Yocto Project meta-oracle-java layer seems to  be not
+  working  anymore because  Oracle updated its  website and
+  also,  the version this  layer provides is not available.
+  To circumvent this I cloned the  repo above, upgraded the
+  recipe  pointing latest version available  at Oracle site
+  However,  since Oracle  now demands  one to  login before
+  download,  the recipe will  fail  do_fetch. Please follow
+  my repo README instructions in order to manually download
+  package; after that recipe will skip do_fetch and install
+  Java correctly.
+
 
 Patches
 =======


### PR DESCRIPTION
Due to Oracle website changes meta-oracle-java hosted by yocto project
is not working anymore. I create a clone to workaround the issue and
suggested it here. However, even my clone does not work very well since
Oracle now demands login and disallow direct dowloads. It is only
a suggestion to alternative source yet not final solution until yocto
project update their recipe.
